### PR TITLE
Add option to skip versioning of js & css files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.3.0
+
+- Add `skip-versioning` flag to disable automatic hash-based versioning for js & css files
+- Fix bug where the upload would fail if a glob pattern matched a directory
+
 0.2.0
 
 - Add `format` flag for json or csv manifest output format

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,47 @@
-hash: 7a6c0cb5f1bdb57d6eeec927bb218fea1867a05a4007c113b09b15e8edf6cc89
-updated: 2017-05-24T14:46:15.136419047-07:00
+hash: e1da4bc94060e653a11f1a2db9e10096e968fa1c5bf09db88db8c9303961843d
+updated: 2019-01-22T11:49:24.767164+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: e8177d9867544fa4677f40ceb470e60b6f3573ae
+  version: 96358b8282b1a3aa66836d2f2fe66216cc419668
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - internal/shareddefaults
+  - private/protocol
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
+  - service/s3
+  - service/s3/s3iface
+  - service/s3/s3manager
+  - service/sts
+- name: github.com/go-ini/ini
+  version: 6ed8d5f64cd79a498d1f3fab5880cc376ce41bbe
+- name: github.com/jmespath/go-jmespath
+  version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
+- name: github.com/spf13/afero
+  version: a5d6946387efe7d64d09dcba68cdd523dc1273a3
+  subpackages:
+  - mem
+- name: golang.org/x/text
+  version: f21a4dfb5e38f5895301dc265a8def02365cc3d0
+  subpackages:
+  - transform
+  - unicode/norm
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,3 +2,9 @@ package: .
 import:
 - package: github.com/aws/aws-sdk-go
   version: ~1.8.29
+- package: github.com/spf13/afero
+  version: ^1.2.0
+- package: golang.org/x/text
+  version: ^0.3.0
+  subpackages:
+  - transform

--- a/main.go
+++ b/main.go
@@ -160,6 +160,14 @@ func GetUploadFilename(file io.Reader, filename string, skipVersioning bool) (st
 	return uploadFilename, nil
 }
 
+func IsDirectory(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return info.IsDir(), err
+}
+
 // VersionAndUploadFiles will verion files and upload them to s3 and return
 // a map of filenames and their version hashes
 func VersionAndUploadFiles(
@@ -174,6 +182,10 @@ func VersionAndUploadFiles(
 	fmt.Printf("Uploading to %s/%s\n", bucket, directory)
 
 	for _, filename := range filenames {
+		isDir, err := IsDirectory(filename)
+		if isDir || err != nil {
+			continue
+		}
 		file, err := os.Open(filename)
 		if err != nil {
 			return fileVersions, err

--- a/main.go
+++ b/main.go
@@ -250,7 +250,11 @@ func main() {
 	if err != nil {
 		fatal("failed to get files %s", err)
 	}
-	fmt.Printf("Found %d files to upload and version:\n", len(files))
+	append := " and version"
+	if *skipVersioning == true {
+		append = ""
+	}
+	fmt.Printf("Found %d files to upload%s:\n", len(files), append)
 
 	SetupS3Uploader()
 	fileVersions, err := VersionAndUploadFiles(*s3Bucket, *directory, files, *dryRun, *skipVersioning)

--- a/main.go
+++ b/main.go
@@ -143,14 +143,14 @@ func UploadFile(file *os.File, filename string, bucket string) (err error) {
 	return nil
 }
 
-func ShouldVersionFile(filename string, skipVersioning bool) (bool) {
+func ShouldVersionFile(filename string) bool {
 	ext := filepath.Ext(filename)
-	return !skipVersioning && (ext == ".js" || ext == ".css")
+	return ext == ".js" || ext == ".css"
 }
 
 func GetUploadFilename(file io.Reader, filename string, skipVersioning bool) (string, error) {
 	uploadFilename := filename
-	if ShouldVersionFile(filename, skipVersioning) {
+	if !skipVersioning && ShouldVersionFile(filename) {
 		checksum, errMd5 := GetFileMd5(file)
 		if errMd5 != nil {
 			return "", errMd5

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"testing"
+
 	"github.com/spf13/afero"
 )
 
@@ -25,22 +26,18 @@ func TestGetFileURL(t *testing.T) {
 	}
 }
 
-
 func TestShouldVersionFile(t *testing.T) {
 	tests := []struct {
-		filename		string
-		skipVersioning bool
-		expected       bool
-	} {
-		{ "bundle.js", false, true },
-		{ "bundle.js", true, false },
-		{ "assets.css", false, true },
-		{ "assets.css", true, false },
-		{ "another.file", false, false },
+		filename string
+		expected bool
+	}{
+		{"bundle.js", true},
+		{"assets.css", true},
+		{"another.file", false},
 	}
 
 	for _, test := range tests {
-		actual := ShouldVersionFile(test.filename, test.skipVersioning)
+		actual := ShouldVersionFile(test.filename)
 		if actual != test.expected {
 			t.Errorf("ShouldVersionFile result was incorrect, got %t, expected %t for filename %s", actual, test.expected, test.filename)
 		}
@@ -53,13 +50,13 @@ func TestGetUploadFilename(t *testing.T) {
 	file, _ := AppFs.OpenFile(filename, os.O_CREATE, 0600)
 	file.WriteString("some JS content")
 	tests := []struct {
-		file afero.File
-		filename string
+		file           afero.File
+		filename       string
 		skipVersioning bool
-		expected string
-	} {
-		{ file, filename, false, "bundle.d41d8cd98f00b204e9800998ecf8427e.js" },
-		{ file, filename, true, "bundle.js" },
+		expected       string
+	}{
+		{file, filename, false, "bundle.d41d8cd98f00b204e9800998ecf8427e.js"},
+		{file, filename, true, "bundle.js"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Test the approach mentioned in https://github.com/bufferapp/buffer-static-upload/issues/12

Currently testing it in https://github.com/bufferapp/buffer-analyze/pull/338 (released the package as `v0.2.2-alpha.2` and everything looks great!