### PR TITLE
Fix: Too many open files while uploading static assets

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 // VERSION is the current version
-const VERSION = "0.2.1"
+const VERSION = "0.4.0"
 
 var defaultS3Bucket = "static.buffer.com"
 var uploader *s3manager.Uploader
@@ -190,7 +190,6 @@ func VersionAndUploadFiles(
 		if err != nil {
 			return fileVersions, err
 		}
-		defer file.Close()
 
 		uploadFilename, err := GetUploadFilename(file, filename, skipVersioning)
 		if err != nil {
@@ -214,6 +213,7 @@ func VersionAndUploadFiles(
 		}
 
 		fileVersions[filename] = fileURL
+		file.Close()
 	}
 
 	return fileVersions, nil


### PR DESCRIPTION
moved file.close() to the end of the loop as opposed to deferring the call. This is because deferring the call would close all the files after the function scope is finished which results in an accumelated number of open files. This causes the utility to crash when too many files are being uploaded all at once.